### PR TITLE
Modify "ibus-hangul" to GETTEXT_PACKAGE

### DIFF
--- a/src/engine.c
+++ b/src/engine.c
@@ -731,7 +731,7 @@ h_ibus_text_get_substring (IBusText* ibus_text, glong p1, glong p2)
 static HanjaList*
 ibus_hangul_engine_lookup_hanja_table (const char* key, int method)
 {
-    HanjaList* list;
+    HanjaList* list = NULL;
 
     if (key == NULL)
         return NULL;

--- a/src/main.c
+++ b/src/main.c
@@ -132,7 +132,7 @@ main (gint argc, gchar **argv)
 
     context = g_option_context_new ("- ibus hangul engine component");
 
-    g_option_context_add_main_entries (context, entries, "ibus-hangul");
+    g_option_context_add_main_entries (context, entries, GETTEXT_PACKAGE);
 
     if (!g_option_context_parse (context, &argc, &argv, &error)) {
         g_print ("Option parsing failed: %s\n", error->message);


### PR DESCRIPTION
Using GETTEXT_PACKAGE in g_option_context_add_main_entries()
makes codes more readable and unified.

src/main.c 파일에서는 GETTEXT_PACKAGE 매크로 변수를 통해 i18n 정보를 관리하고 있습니다. 따라서 g_option_context_add_main_entries() 함수에서 "ibus-hangul"을 사용하는 것 보다 GETTEXT_PACKAGE를 사용하는 것이 나을 듯 합니다. 
Glib 메뉴얼에서도 이와 같이 사용하고 있습니다. 
- https://developer.gnome.org/glib/stable/glib-Commandline-option-parser.html
- https://developer.gnome.org/glib/stable/glib-I18N.html

감사합니다.