### PR TITLE
Initialized local variable as NULL

### DIFF
--- a/src/engine.c
+++ b/src/engine.c
@@ -731,7 +731,7 @@ h_ibus_text_get_substring (IBusText* ibus_text, glong p1, glong p2)
 static HanjaList*
 ibus_hangul_engine_lookup_hanja_table (const char* key, int method)
 {
-    HanjaList* list;
+    HanjaList* list = NULL;
 
     if (key == NULL)
         return NULL;


### PR DESCRIPTION
Uninitialized local variable has garbage data. It can cause a problem when
ibus-hangul fails to load hanja-table. So this commit initializes local
variable "list" as NULL.

일반적으로 symbol.txt 로딩에 성공할 것이기 때문에, 대부분의 경우 해당 부분에 문제가 생기지는 않습니다. 하지만, symbol.txt 로딩에 실패할 경우 list가 NULL인지 검사하는 로직이 정상 작동하지 않습니다. 안전하게 list를 선언할 때 NULL로 초기화 하면 좋겠습니다.

감사합니다.