### PR TITLE
setup: Add window "destroy" event handling

### DIFF
--- a/setup/main.py
+++ b/setup/main.py
@@ -151,6 +151,7 @@ class Setup ():
         self.__window = self.__builder.get_object("SetupDialog")
         icon_file = os.path.join(config.pkgdatadir, "icons", "ibus-hangul.svg")
         self.__window.set_icon_from_file(icon_file)
+        self.__window.connect("destroy", Gtk.main_quit)
         self.__window.show()
 
         button = self.__builder.get_object("button_apply")


### PR DESCRIPTION
It corrects the setup program to quit on window close.

8fa56314b70129372b4854d5e0442876911469e2 관련.  GtkWindow로 바뀌면서 창을 닫으면 종료되지 않는 사항 수정.

