### PR TITLE
Migrate to autoreconf and gettext

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,9 +35,6 @@ stamp-h1
 py-compile
 ibus-hangul*.tar.*
 ibus-hangul.spec
-intltool-extract.in
-intltool-merge.in
-intltool-update.in
 
 # vim temp backup file
 .*.swp
@@ -49,7 +46,6 @@ data/org.freedesktop.ibus.engine.hangul.metainfo.xml.h
 # files for po
 po/*.gmo
 po/*.pot
-po/.intltool-merge-cache
 po/stamp-po
 po/stamp-it
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,24 +1,41 @@
 #!/bin/sh
 # Run this to generate all the initial makefiles, etc.
+test -n "$srcdir" || srcdir=$(dirname "$0")
+test -n "$srcdir" || srcdir=.
 
-srcdir=`dirname $0`
-test -z "$srcdir" && srcdir=.
+olddir=$(pwd)
 
-PKG_NAME="ibus-hangul"
+cd "$srcdir"
 
-(test -f $srcdir/configure.ac \
-  && test -f $srcdir/README ) || {
+(test -f configure.ac) || {
     echo -n "**Error**: Directory "\`$srcdir\'" does not look like the"
     echo " top-level $PKG_NAME directory"
     exit 1
 }
 
-which gnome-autogen.sh || {
-    echo "You need to install gnome-common from the GNOME CVS"
-    exit 1
-}
+# shellcheck disable=SC2016
+PKG_NAME=$(autoconf --trace 'AC_INIT:$1' configure.ac)
 
-ACLOCAL_FLAGS="$ACLOCAL_FLAGS -I m4"
-REQUIRED_AUTOMAKE_VERSION=1.8
+if [ "$#" = 0 -a "x$NOCONFIGURE" = "x" ]; then
+        echo "*** WARNING: I am going to run 'configure' with no arguments." >&2
+        echo "*** If you wish to pass any to it, please specify them on the" >&2
+        echo "*** '$0' command line." >&2
+        echo "" >&2
+fi
 
-. gnome-autogen.sh
+aclocal --install || exit 1
+intltoolize --force --copy --automake || exit 1
+autoreconf --verbose --force --install || exit 1
+
+cd "$olddir"
+if [ "$NOCONFIGURE" = "" ]; then
+        $srcdir/configure "$@" || exit 1
+
+        if [ "$1" = "--help" ]; then
+                exit 0
+        else
+                echo "Now type 'make' to compile $PKG_NAME" || exit 1
+        fi
+else
+        echo "Skipping configure process."
+fi

--- a/autogen.sh
+++ b/autogen.sh
@@ -24,7 +24,6 @@ if [ "$#" = 0 -a "x$NOCONFIGURE" = "x" ]; then
 fi
 
 aclocal --install || exit 1
-intltoolize --force --copy --automake || exit 1
 autoreconf --verbose --force --install || exit 1
 
 cd "$olddir"

--- a/configure.ac
+++ b/configure.ac
@@ -51,7 +51,8 @@ AC_ISC_POSIX
 AC_HEADER_STDC
 AM_PROG_LIBTOOL
 
-IT_PROG_INTLTOOL([0.35.0])
+AM_GNU_GETTEXT_VERSION([0.19.8])
+AM_GNU_GETTEXT([external])
 
 # check ibus
 PKG_CHECK_MODULES(IBUS, [
@@ -76,13 +77,16 @@ AC_ARG_WITH(python,
 AM_PATH_PYTHON([2.5])
 
 # define GETTEXT_* variables
-GETTEXT_PACKAGE=ibus-hangul
+GETTEXT_PACKAGE=AC_PACKAGE_NAME
 AC_SUBST(GETTEXT_PACKAGE)
-AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE,"$GETTEXT_PACKAGE", [Define to the read-only architecture-independent data directory.])
-
+AC_DEFINE_UNQUOTED(
+  GETTEXT_PACKAGE, "$GETTEXT_PACKAGE",
+    [Define to the read-only architecture-independent data directory.]
+)
 
 # OUTPUT files
-AC_CONFIG_FILES([ po/Makefile.in
+AC_CONFIG_FILES([
+po/Makefile.in
 Makefile
 ibus-hangul.spec
 src/Makefile

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -32,9 +32,12 @@ symboltable_DATA = \
 symboltabledir = $(datadir)/ibus-hangul/data
 
 appstream_in_files = org.freedesktop.ibus.engine.hangul.metainfo.xml.in
-appstream_DATA = $(appstream_in_files:.xml.in=.xml)
+appstream_files = $(appstream_in_files:.xml.in=.xml)
+appstream_DATA = $(appstream_files)
 appstreamdir=$(datadir)/metainfo
-@INTLTOOL_XML_RULE@
+
+$(appstream_files): $(appstream_in_files) Makefile
+	$(AM_V_GEN)$(MSGFMT) --xml --template $< -d $(top_srcdir)/po -o $@
 
 install-data-hook:
 	if test -z "$(DESTDIR)"; then \

--- a/data/org.freedesktop.ibus.engine.hangul.metainfo.xml.in
+++ b/data/org.freedesktop.ibus.engine.hangul.metainfo.xml.in
@@ -4,11 +4,9 @@
   <name>ibus-hangul</name>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2</project_license>
-  <_summary>Hangul engine for IBus</_summary>
+  <summary>Hangul engine for IBus</summary>
   <description>
-    <_p>
- IBus-Hangul is a Korean input method engine for IBus.
-    </_p>
+    <p>IBus-Hangul is a Korean input method engine for IBus.</p>
   </description>
   <project_group>IBus</project_group>
   <url type="homepage">https://github.com/libhangul/ibus-hangul</url>

--- a/m4/Makefile.am
+++ b/m4/Makefile.am
@@ -20,4 +20,12 @@
 
 EXTRA_DIST = \
     as-version.m4 \
+    gettext.m4 \
+    iconv.m4 \
+    lib-ld.m4 \
+    lib-link.m4 \
+    lib-prefix.m4 \
+    nls.m4 \
+    po.m4 \
+    progtest.m4 \
     $(NULL)

--- a/po/Makevars
+++ b/po/Makevars
@@ -8,7 +8,7 @@ subdir = po
 top_builddir = ..
 
 # These options get passed to xgettext.
-XGETTEXT_OPTIONS = --keyword=_ --keyword=N_
+XGETTEXT_OPTIONS = --from-code=UTF-8 --keyword=_ --keyword=N_ --keyword=C_:1c,2 --keyword=NC_:1c,2 --keyword=g_dngettext:2,3 --add-comments
 
 # This is the copyright holder that gets inserted into the header of the
 # $(DOMAIN).pot file.  Set this to the copyright holder of the surrounding
@@ -19,6 +19,13 @@ XGETTEXT_OPTIONS = --keyword=_ --keyword=N_
 # the public domain; in this case the translators are expected to disclaim
 # their copyright.
 COPYRIGHT_HOLDER = Huang Peng <shawn.p.huang@gmail.com>
+
+# This tells whether or not to prepend "GNU " prefix to the package
+# name that gets inserted into the header of the $(DOMAIN).pot file.
+# Possible values are "yes", "no", or empty.  If it is empty, try to
+# detect it automatically by scanning the files in $(top_srcdir) for
+# "GNU packagename" string.
+PACKAGE_GNU = no
 
 # This is the email address or URL to which the translators shall report
 # bugs in the untranslated strings:
@@ -39,3 +46,33 @@ MSGID_BUGS_ADDRESS = $(PACKAGE_BUGREPORT)
 # This is the list of locale categories, beyond LC_MESSAGES, for which the
 # message catalogs shall be used.  It is usually empty.
 EXTRA_LOCALE_CATEGORIES =
+
+# This tells whether the $(DOMAIN).pot file contains messages with an 'msgctxt'
+# context.  Possible values are "yes" and "no".  Set this to yes if the
+# package uses functions taking also a message context, like pgettext(), or
+# if in $(XGETTEXT_OPTIONS) you define keywords with a context argument.
+USE_MSGCTXT = yes
+
+# These options get passed to msgmerge.
+# Useful options are in particular:
+#   --previous            to keep previous msgids of translated messages,
+#   --quiet               to reduce the verbosity.
+MSGMERGE_OPTIONS =
+
+# These options get passed to msginit.
+# If you want to disable line wrapping when writing PO files, add
+# --no-wrap to MSGMERGE_OPTIONS, XGETTEXT_OPTIONS, and
+# MSGINIT_OPTIONS.
+MSGINIT_OPTIONS =
+
+# This tells whether or not to regenerate a PO file when $(DOMAIN).pot
+# has changed.  Possible values are "yes" and "no".  Set this to no if
+# the POT file is checked in the repository and the version control
+# program ignores timestamps.
+PO_DEPENDS_ON_POT = no
+
+# This tells whether or not to forcibly update $(DOMAIN).pot and
+# regenerate PO files on "make dist".  Possible values are "yes" and
+# "no".  Set this to no if the POT file and PO files are maintained
+# externally.
+DIST_DEPENDS_ON_UPDATE_PO = no

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,7 +1,7 @@
-[type: gettext/xml]data/org.freedesktop.ibus.engine.hangul.metainfo.xml.in
+data/org.freedesktop.ibus.engine.hangul.metainfo.xml.in
 setup/keycapturedialog.py
 setup/main.py
 setup/ibus-setup-hangul.desktop.in
-[type: gettext/glade]setup/setup.ui
+setup/setup.ui
 src/engine.c
 src/main.c

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -1,0 +1,2 @@
+data/org.freedesktop.ibus.engine.hangul.metainfo.xml
+setup/ibus-setup-hangul.desktop

--- a/setup/Makefile.am
+++ b/setup/Makefile.am
@@ -31,9 +31,12 @@ setup_hanguldir = $(pkgdatadir)/setup
 libexec_SCRIPTS = ibus-setup-hangul
 
 desktop_in_files = ibus-setup-hangul.desktop.in
-desktop_DATA = ibus-setup-hangul.desktop
+desktop_files = $(desktop_in_files:.desktop.in=.desktop)
+desktop_DATA = $(desktop_files)
 desktopdir = $(datadir)/applications
-@INTLTOOL_DESKTOP_RULE@
+
+$(desktop_files): $(desktop_in_files) Makefile
+	$(AM_V_GEN)$(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
 
 hicolor_icon_64_DATA = ibus-setup-hangul.png
 hicolor_icon_64dir = $(datadir)/icons/hicolor/64x64/apps

--- a/setup/ibus-setup-hangul.desktop.in
+++ b/setup/ibus-setup-hangul.desktop.in
@@ -1,6 +1,6 @@
 [Desktop Entry]
-_Name=IBus Hangul Preferences
-_Comment=Set IBus Hangul Preferences
+Name=IBus Hangul Preferences
+Comment=Set IBus Hangul Preferences
 Exec=ibus-setup-hangul
 Icon=ibus-setup-hangul
 NoDisplay=true


### PR DESCRIPTION
Current `ibus-hangul` build system relies on `gnome-common` and `intltool` but they are both deprecated. This patch ports the build scripts to plain `autoreconf` and recent `gettext`:

https://wiki.gnome.org/Projects/GnomeCommon/Migration
https://wiki.gnome.org/Initiatives/GnomeGoals/GettextMigration

Fixes https://github.com/libhangul/ibus-hangul/issues/80.