### PR TITLE
Specify the setup path in the IBus component XML

### DIFF
--- a/src/hangul.xml.in.in
+++ b/src/hangul.xml.in.in
@@ -23,6 +23,7 @@
 			<description>Korean Input Method</description>
 			<rank>99</rank>
 			<symbol>&#xD55C;</symbol>
+			<setup>${libexecdir}/ibus-setup-hangul</setup>
 		</engine>
 	</engines>
 


### PR DESCRIPTION
It's always good to specify the setup path explicitly. If it's not specified,
ibus-setup finds ibus-setup-hangul in libexec, assuming ibus-hangul uses the
same libexec as ibus. Depending on this fallback makes it difficult to migrate
from FHS 2.0 (/usr/lib) to FHS 3.0 (/usr/libexec).