### PR TITLE
Change the definition of IBUS_CAP_SYNC_PROCESS_KEY

### DIFF
--- a/src/engine.c
+++ b/src/engine.c
@@ -1578,8 +1578,8 @@ ibus_hangul_engine_process_key_event (IBusEngine     *engine,
      * See: https://github.com/choehwanjin/ibus-hangul/issues/40
      */
     if (use_event_forwarding
-#if IBUS_CHECK_VERSION(1, 5, 27)
-        && !(hangul->caps & IBUS_CAP_SYNC_PROCESS_KEY)
+#if IBUS_CHECK_VERSION(1, 5, 28)
+        && (hangul->caps & IBUS_CAP_SYNC_PROCESS_KEY_V2)
 #endif
         ) {
         if (!retval) {


### PR DESCRIPTION
After the new proces key event is integrated in ibus-x11, IBUS_CAP_SYNC_PROCESS_KEY capability is now set the sync mode only since ibus-hangul requires forward-key-event for the sync mode only.